### PR TITLE
fix: add createRequire to not auto fail on googleapis import

### DIFF
--- a/src/services/providers/google-provider.ts
+++ b/src/services/providers/google-provider.ts
@@ -1,5 +1,8 @@
+import { createRequire } from 'module';
 import { SearchResult, SearchFilters, SearchPaginationInfo } from '../../types.js';
 import { BaseSearchProvider, ProviderInfo, ProviderError, ProviderSearchResponse } from './base-provider.js';
+
+const require = createRequire(import.meta.url);
 
 /**
  * Google Custom Search provider implementation


### PR DESCRIPTION
the googleapis import necessary to use Google PSE will always fail silently and then throw the package not installed error since require is not available by default in an esm module.

This polyfill will allow it to still be used while maintaining the async package check, which is a bit more complex with import.